### PR TITLE
fix: correct typo in code-mirror-utils.js - I would be glad to become your contributor

### DIFF
--- a/src/client/utils/code-mirror-utils.js
+++ b/src/client/utils/code-mirror-utils.js
@@ -1,4 +1,3 @@
-
 function isBlank(str) {
   return (/^\s*$/.test(str));
 }
@@ -15,7 +14,7 @@ export function hasCleanLeft(start) {
 // `this` is a codemirror
 export function hasCleanRight(pos) {
   const backLineEnd = {
-    co: Infinity,
+    ch: Infinity,
     line: pos.line
   };
   return isBlank(this.getRange(pos, backLineEnd));


### PR DESCRIPTION
### Summary of changes
Corrected a typo in the `hasCleanRight` utility function within `src/client/utils/code-mirror-utils.js`, where the property `co` was incorrectly used instead of `ch` to define the column index for a CodeMirror range calculation.

### Rationale behind the implementation
The property `co` is not a valid CodeMirror range position attribute, which would cause the `hasCleanRight` function to fail when calculating the range. The correct attribute is `ch`.

### Technical impact analysis
This fix ensures that `hasCleanRight` correctly identifies the range to the right of the given position, restoring the intended functionality of checking for blank space in CodeMirror editors within the Lively4 environment.